### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,20 @@
 
 metis-replica-node, adjusted to work with central-proxy-docker
 
-`cp default.env .env`, adjust the L1 RPC to your own Ethereum node, and `./metisd up`
+`cp default.env .env`, adjust the `DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT` and
+`DATA_TRANSPORT_LAYER__L1_BEACON_ENDPOINT`to your own Ethereum node. If you need or want the finality tag to be
+up-to-date in l2geth RPC, set `DATA_TRANSPORT_LAYER__SYNC_L1_BATCH=true`.
+
+For faster sync, set a `DTL_SNAPSHOT` and `SNAPSHOT`. Note l2geth won't sync until l1dtl is up-to-date.
+
+To start, `./metisd up`. To update, `./metisd update` followed by `./metisd up`.
 
 The Ethereum node need not be an archive, but should have full eth_getLogs and tx indexing. For Geth
 `--history.transactions=0` and for Nethermind `--Receipt.TxLookupLimit=0`.
+
+If you are syncing l1dtl from scratch or an old snapshot, you may need an archive RPC during sync only, so that
+`eth_getBlockByNumber` succeeds.
+
+`custom.yml` is not tracked by git and can be used to override anything in the provided `metis.yml`
 
 This is Metis Docker v1.2.0

--- a/default.env
+++ b/default.env
@@ -6,7 +6,7 @@ HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://andromeda.metis.io/?owner=1088
 HEALTHCHECK__TARGET_RPC_PROVIDER=http://l2geth:8545
 REPLICA_HEALTHCHECK__ETH_NETWORK=mainnet
 HC_IMAGE_TAG=
-DTL_IMAGE_TAG=v0.2.2-1
+DTL_IMAGE_TAG=v0.2.2-2
 L2GETH_IMAGE_TAG=v0.3.7
 GCMODE=full
 # Snapshots. If omitted sync from scratch


### PR DESCRIPTION
More details around .env parameters and finality as well as `SNAPSHOT`

Bumped l1dtl default version to `v0.2.2-2`, as it contains a vital fix for syncing with batch / finality enabled
